### PR TITLE
CDStack.save(): print nice error for optional attribute/relationship missing

### DIFF
--- a/notes/Project_Templates/CoreDataModel/Classes/CDStack.swift
+++ b/notes/Project_Templates/CoreDataModel/Classes/CDStack.swift
@@ -80,6 +80,18 @@ class CDStack {
             do {
                 try managedObjectContext.save()
             } catch let error as NSError {
+                if let details = error.userInfo["NSDetailedErrors"] as? [NSError] {
+                    for detail in details {
+                        if let badKey = detail.userInfo["NSValidationErrorKey"], let badObject = detail.userInfo["NSValidationErrorObject"] {
+                            let msg = "Error on save, check Core Data constraints on '\(badKey)'.\n" +
+                                "(A non-optional attribute/relationship in core data can cause this.)\n" +
+                            "Attempted to save object: \(badObject)"
+                            print(msg)
+                        }
+                    }
+                }
+                // In a production app, you may not want a fatal error here. Is this something you should
+                // warn the user about instead? Perhaps there is a way to recover from a problem saving.
                 fatalError("CDStack save error \(error), \(error.userInfo)")
             }
         }


### PR DESCRIPTION
Nice error looks like:

<img width="525" alt="screen shot 2017-02-15 at 5 18 32 pm 2" src="https://cloud.githubusercontent.com/assets/5495083/22998150/7a07f9b4-f3a3-11e6-975c-fed8e0e97249.png">
