### PR TITLE
Updates to WebService example

### DIFF
--- a/notes/Project_Templates/WebServiceModel/Classes/WebServiceModel.swift
+++ b/notes/Project_Templates/WebServiceModel/Classes/WebServiceModel.swift
@@ -32,7 +32,7 @@ class WebServiceModel {
     // Method to fetch the collection
     func programsGet() {
         let request = WebServiceRequest()
-        request.sendRequest(toUrlPath: "/programs", dataKeyName: nil, propertyNamed: nil, completion: {
+        request.sendRequest(toUrlPath: "/programs", dataKeyName: nil, completion: {
             (result: [AnyObject]) in
             for item in result {
                 guard let programDict = item as? [String:AnyObject] else {


### PR DESCRIPTION
- Simplify sendRequest() to have only a dataKeyName and not a propertyName argument.

- Change URLSession creation to just use: let session = URLSession.shared, but expain in the comment block how to create a non-default configuration/session